### PR TITLE
Fix: Correct PaymentURL on hybrid

### DIFF
--- a/cmd/internal/setup.go
+++ b/cmd/internal/setup.go
@@ -132,7 +132,7 @@ func SetupHybrid(cfg config.Config, l log.Logger, e *echo.Echo) *server.SocketSe
 		noopStore := noop.NewNoOp(log.Noop{})
 		paymentSvc = service.NewPayment(log.Noop{}, noopStore)
 	}
-	paymentReqSvc := service.NewPaymentRequestProxy(paymentStore)
+	paymentReqSvc := service.NewPaymentRequestProxy(paymentStore, cfg.Transports, cfg.Server)
 	proofsSvc := service.NewProof(paymentStore)
 
 	p4Handlers.NewPaymentHandler(paymentSvc).RegisterRoutes(g)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: local.p4
     environment:
       LOG_LEVEL: "info"
-      TRANSPORT_MODE: 'http'
+      TRANSPORT_MODE: 'hybrid'
     ports:
       - "8445:8445"
     networks:
@@ -19,7 +19,7 @@ services:
       LOG_LEVEL: "info"
       PAYD_HOST: "payd-merchant"
       PAYD_PORT: ":28443"
-      TRANSPORT_MODE: 'http'
+      TRANSPORT_MODE: 'hybrid'
       SERVER_HOST: "p4"
       SERVER_PORT: ":28445"
     ports:


### PR DESCRIPTION
Currently, hybrid payment requests would return `paymentURL: "ws://p4:8445/ws"`, even though they are expecting to be interfaced with via http.

This intercepts the message from payd and swaps out the payment request url, as to leave payd ignorant of how p4 is to be interfaced.