### PR TITLE
Enhancement: Use Payd PaymentRequest Endpoint

### DIFF
--- a/cmd/internal/setup.go
+++ b/cmd/internal/setup.go
@@ -53,11 +53,11 @@ func SetupDeps(cfg config.Config, l log.Logger) *Deps {
 
 	// services
 	paymentSvc := service.NewPayment(l, paydStore)
-	paymentReqSvc := service.NewPaymentRequest(cfg.Server, paydStore, paydStore)
+	paymentReqSvc := service.NewPaymentRequest(paydStore)
 	if cfg.PayD.Noop {
 		noopStore := noop.NewNoOp(log.Noop{})
 		paymentSvc = service.NewPayment(log.Noop{}, noopStore)
-		paymentReqSvc = service.NewPaymentRequest(cfg.Server, noopStore, noopStore)
+		paymentReqSvc = service.NewPaymentRequest(noopStore)
 	}
 	proofService := service.NewProof(paydStore)
 

--- a/data/noop/noop.go
+++ b/data/noop/noop.go
@@ -2,6 +2,7 @@ package noop
 
 import (
 	"context"
+	"time"
 
 	"github.com/libsv/go-bt/v2"
 	"github.com/libsv/p4-server/log"
@@ -29,29 +30,32 @@ func (n *noop) PaymentCreate(ctx context.Context, args p4.PaymentCreateArgs, req
 	return &p4.PaymentACK{}, nil
 }
 
-// Owner will return information regarding the owner of a payd wallet.
-//
-// In this example, the payd wallet has no auth, in proper implementations auth would
-// be enabled and a cookie / oauth / bearer token etc would be passed down.
-func (n *noop) Owner(ctx context.Context) (*p4.Merchant, error) {
-	n.l.Info("hit noop.Owner")
-	return &p4.Merchant{
-		AvatarURL:    "noop",
-		Name:         "noop",
-		Email:        "noop",
-		Address:      "noop",
-		ExtendedData: nil,
-	}, nil
-}
-
-func (n *noop) Destinations(ctx context.Context, args p4.PaymentRequestArgs) (*p4.Destinations, error) {
-	n.l.Info("hit noop.Destinations")
-	return &p4.Destinations{
-		Outputs: []p4.Output{{
-			Amount:      0,
-			Script:      "noop",
-			Description: "noop",
-		}},
-		Fees: bt.NewFeeQuote(),
+func (n noop) PaymentRequest(ctx context.Context, args p4.PaymentRequestArgs) (*p4.PaymentRequest, error) {
+	return &p4.PaymentRequest{
+		Network:             "noop",
+		CreationTimestamp:   time.Now(),
+		ExpirationTimestamp: time.Now().Add(time.Hour),
+		FeeRate: func() *bt.FeeQuote {
+			fq := bt.NewFeeQuote()
+			fq.UpdateExpiry(time.Now().Add(10 * time.Hour))
+			return fq
+		}(),
+		Memo:        "noop",
+		PaymentURL:  "noop",
+		SPVRequired: true,
+		MerchantData: &p4.Merchant{
+			AvatarURL:    "noop",
+			Name:         "noop",
+			Email:        "noop",
+			Address:      "noop",
+			ExtendedData: nil,
+		},
+		Destinations: p4.PaymentDestinations{
+			Outputs: []p4.Output{{
+				Amount:      0,
+				Script:      "noop",
+				Description: "noop",
+			}},
+		},
 	}, nil
 }

--- a/data/payd/payd.go
+++ b/data/payd/payd.go
@@ -36,6 +36,16 @@ func NewPayD(cfg *config.PayD, client data.HTTPClient) *payd {
 	}
 }
 
+// PaymentRequest will fetch a payment request message from payd for a given payment.
+func (p *payd) PaymentRequest(ctx context.Context, args p4.PaymentRequestArgs) (*p4.PaymentRequest, error) {
+	var resp p4.PaymentRequest
+	if err := p.client.Do(ctx, http.MethodGet, fmt.Sprintf(urlPayments, p.baseURL(), args.PaymentID), http.StatusOK, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 // PaymentCreate will post a request to payd to validate and add the txos to the wallet.
 //
 // If invalid a non 204 status code is returned.

--- a/data/payd/payd.go
+++ b/data/payd/payd.go
@@ -17,8 +17,6 @@ import (
 // Known endpoints for the payd wallet implementing the payment protocol interface.
 const (
 	urlPayments      = "%s/api/v1/payments/%s"
-	urlOwner         = "%s/api/v1/owner"
-	urlDestinations  = "%s/api/v1/destinations/%s"
 	urlProofs        = "%s/api/v1/proofs/%s"
 	protocolInsecure = "http"
 	protocolSecure   = "https"
@@ -54,41 +52,6 @@ func (p *payd) PaymentCreate(ctx context.Context, args p4.PaymentCreateArgs, req
 		Memo:    req.Memo,
 		Payment: &req,
 	}, nil
-}
-
-// Owner will return information regarding the owner of a payd wallet.
-//
-// In this example, the payd wallet has no auth, in proper implementations auth would
-// be enabled and a cookie / oauth / bearer token etc would be passed down.
-func (p *payd) Owner(ctx context.Context) (*p4.Merchant, error) {
-	var owner *p4.Merchant
-	if err := p.client.Do(ctx, http.MethodGet, fmt.Sprintf(urlOwner, p.baseURL()), http.StatusOK, nil, &owner); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return owner, nil
-}
-
-func (p *payd) Destinations(ctx context.Context, args p4.PaymentRequestArgs) (*p4.Destinations, error) {
-	var resp models.DestinationResponse
-	if err := p.client.Do(ctx, http.MethodGet, fmt.Sprintf(urlDestinations, p.baseURL(), args.PaymentID), http.StatusOK, nil, &resp); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	dests := &p4.Destinations{
-		SPVRequired: resp.SPVRequired,
-		Network:     resp.Network,
-		Outputs:     make([]p4.Output, 0),
-		Fees:        resp.Fees,
-		CreatedAt:   resp.CreatedAt,
-		ExpiresAt:   resp.ExpiresAt,
-	}
-	for _, o := range resp.Outputs {
-		dests.Outputs = append(dests.Outputs, p4.Output{
-			Amount: o.Satoshis,
-			Script: o.Script,
-		})
-	}
-
-	return dests, nil
 }
 
 // ProofCreate will pass on the proof to a payd instance for storage.

--- a/service/paymentrequest_test.go
+++ b/service/paymentrequest_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/libsv/go-p4"
 	p4mocks "github.com/libsv/go-p4/mocks"
-	"github.com/libsv/p4-server/config"
 	"github.com/libsv/p4-server/service"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,74 +16,31 @@ func TestPaymentRequest_PaymentRequest(t *testing.T) {
 	created := time.Now()
 	expired := created.Add(time.Hour * 24)
 	tests := map[string]struct {
-		destinationsFunc func(context.Context, p4.PaymentRequestArgs) (*p4.Destinations, error)
-		ownerFunc        func(context.Context) (*p4.Merchant, error)
-		config           *config.Server
-		args             p4.PaymentRequestArgs
-		expResp          *p4.PaymentRequest
-		expErr           error
+		paymentRequestFunc func(context.Context, p4.PaymentRequestArgs) (*p4.PaymentRequest, error)
+		args               p4.PaymentRequestArgs
+		expResp            *p4.PaymentRequest
+		expErr             error
 	}{
 		"successful request": {
 			args: p4.PaymentRequestArgs{
 				PaymentID: "abc123",
 			},
-			config: &config.Server{
-				FQDN: "iamsotest",
-			},
-			destinationsFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.Destinations, error) {
-				return &p4.Destinations{
-					SPVRequired: false,
-					CreatedAt:   created,
-					ExpiresAt:   expired,
-					Outputs: []p4.Output{{
-						Amount: 500,
-						Script: "abc123",
-					}},
-				}, nil
-			},
-			ownerFunc: func(context.Context) (*p4.Merchant, error) {
-				return &p4.Merchant{
-					ExtendedData: map[string]interface{}{},
-				}, nil
-			},
-			expResp: &p4.PaymentRequest{
-				SPVRequired:         false,
-				CreationTimestamp:   created,
-				ExpirationTimestamp: expired,
-				Destinations: p4.PaymentDestinations{
-					Outputs: []p4.Output{{
-						Amount: 500,
-						Script: "abc123",
-					}},
-				},
-				PaymentURL: "http://iamsotest/api/v1/payment/abc123",
-				Memo:       "invoice abc123",
-				MerchantData: &p4.Merchant{
-					ExtendedData: map[string]interface{}{"paymentReference": "abc123"},
-				},
-			},
-		},
-		"successful request with nil extended data from owner reader": {
-			args: p4.PaymentRequestArgs{
-				PaymentID: "abc123",
-			},
-			config: &config.Server{
-				FQDN: "iamsotest",
-			},
-			destinationsFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.Destinations, error) {
-				return &p4.Destinations{
-					SPVRequired: false,
-					CreatedAt:   created,
-					ExpiresAt:   expired,
-					Outputs: []p4.Output{{
-						Amount: 500,
-						Script: "abc123",
-					}},
-				}, nil
-			},
-			ownerFunc: func(context.Context) (*p4.Merchant, error) {
-				return &p4.Merchant{
-					ExtendedData: nil,
+			paymentRequestFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.PaymentRequest, error) {
+				return &p4.PaymentRequest{
+					SPVRequired:         false,
+					CreationTimestamp:   created,
+					ExpirationTimestamp: expired,
+					Destinations: p4.PaymentDestinations{
+						Outputs: []p4.Output{{
+							Amount: 500,
+							Script: "abc123",
+						}},
+					},
+					PaymentURL: "http://iamsotest/api/v1/payment/abc123",
+					Memo:       "invoice abc123",
+					MerchantData: &p4.Merchant{
+						ExtendedData: map[string]interface{}{"paymentReference": "abc123"},
+					},
 				}, nil
 			},
 			expResp: &p4.PaymentRequest{
@@ -104,27 +60,24 @@ func TestPaymentRequest_PaymentRequest(t *testing.T) {
 				},
 			},
 		},
-		"config fqdn is reflected in payment url": {
+		"successful request with nil extended data": {
 			args: p4.PaymentRequestArgs{
 				PaymentID: "abc123",
 			},
-			config: &config.Server{
-				FQDN: "iamsodifferent",
-			},
-			destinationsFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.Destinations, error) {
-				return &p4.Destinations{
-					SPVRequired: false,
-					CreatedAt:   created,
-					ExpiresAt:   expired,
-					Outputs: []p4.Output{{
-						Amount: 500,
-						Script: "abc123",
-					}},
-				}, nil
-			},
-			ownerFunc: func(context.Context) (*p4.Merchant, error) {
-				return &p4.Merchant{
-					ExtendedData: map[string]interface{}{},
+			paymentRequestFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.PaymentRequest, error) {
+				return &p4.PaymentRequest{
+					SPVRequired:         false,
+					CreationTimestamp:   created,
+					ExpirationTimestamp: expired,
+					Destinations: p4.PaymentDestinations{
+						Outputs: []p4.Output{{
+							Amount: 500,
+							Script: "abc123",
+						}},
+					},
+					MerchantData: &p4.Merchant{},
+					PaymentURL:   "http://iamsotest/api/v1/payment/abc123",
+					Memo:         "invoice abc123",
 				}, nil
 			},
 			expResp: &p4.PaymentRequest{
@@ -137,123 +90,31 @@ func TestPaymentRequest_PaymentRequest(t *testing.T) {
 						Script: "abc123",
 					}},
 				},
-				PaymentURL: "http://iamsodifferent/api/v1/payment/abc123",
+				PaymentURL: "http://iamsotest/api/v1/payment/abc123",
 				Memo:       "invoice abc123",
 				MerchantData: &p4.Merchant{
 					ExtendedData: map[string]interface{}{"paymentReference": "abc123"},
-				},
-			},
-		},
-		"paymentID is reflected in the payment url, the memo, and the extended data": {
-			args: p4.PaymentRequestArgs{
-				PaymentID: "456def",
-			},
-			config: &config.Server{
-				FQDN: "iamsotest",
-			},
-			destinationsFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.Destinations, error) {
-				return &p4.Destinations{
-					SPVRequired: false,
-					CreatedAt:   created,
-					ExpiresAt:   expired,
-					Outputs: []p4.Output{{
-						Amount: 500,
-						Script: "abc123",
-					}},
-				}, nil
-			},
-			ownerFunc: func(context.Context) (*p4.Merchant, error) {
-				return &p4.Merchant{
-					ExtendedData: map[string]interface{}{},
-				}, nil
-			},
-			expResp: &p4.PaymentRequest{
-				SPVRequired:         false,
-				CreationTimestamp:   created,
-				ExpirationTimestamp: expired,
-				Destinations: p4.PaymentDestinations{
-					Outputs: []p4.Output{{
-						Amount: 500,
-						Script: "abc123",
-					}},
-				},
-				PaymentURL: "http://iamsotest/api/v1/payment/456def",
-				Memo:       "invoice 456def",
-				MerchantData: &p4.Merchant{
-					ExtendedData: map[string]interface{}{"paymentReference": "456def"},
 				},
 			},
 		},
 		"invalid args rejected": {
-			config: &config.Server{
-				FQDN: "iamsotest",
-			},
-			destinationsFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.Destinations, error) {
-				return &p4.Destinations{
-					SPVRequired: false,
-					CreatedAt:   created,
-					ExpiresAt:   expired,
-					Outputs: []p4.Output{{
-						Amount: 500,
-						Script: "abc123",
-					}},
-				}, nil
-			},
-			ownerFunc: func(context.Context) (*p4.Merchant, error) {
-				return &p4.Merchant{
-					ExtendedData: map[string]interface{}{},
-				}, nil
-			},
 			expErr: errors.New("[paymentID: value cannot be empty]"),
 		},
-		"destination reader error handled and reported": {
+		"payment request reader error handled and reported": {
 			args: p4.PaymentRequestArgs{
 				PaymentID: "abc123",
 			},
-			config: &config.Server{
-				FQDN: "iamsotest",
-			},
-			destinationsFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.Destinations, error) {
+			paymentRequestFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.PaymentRequest, error) {
 				return nil, errors.New("oh boi")
 			},
-			ownerFunc: func(context.Context) (*p4.Merchant, error) {
-				return &p4.Merchant{
-					ExtendedData: map[string]interface{}{},
-				}, nil
-			},
-			expErr: errors.New("failed to get destinations for paymentID abc123: oh boi"),
-		},
-		"owner reader error handled and reported": {
-			args: p4.PaymentRequestArgs{
-				PaymentID: "abc123",
-			},
-			config: &config.Server{
-				FQDN: "iamsotest",
-			},
-			destinationsFunc: func(context.Context, p4.PaymentRequestArgs) (*p4.Destinations, error) {
-				return &p4.Destinations{
-					SPVRequired: false,
-					CreatedAt:   created,
-					ExpiresAt:   expired,
-					Outputs: []p4.Output{{
-						Amount: 500,
-						Script: "abc123",
-					}},
-				}, nil
-			},
-			ownerFunc: func(context.Context) (*p4.Merchant, error) {
-				return nil, errors.New("yikes")
-			},
-			expErr: errors.New("failed to read merchant data when constructing payment request: yikes"),
+			expErr: errors.New("failed to get payment request for paymentID abc123: oh boi"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			svc := service.NewPaymentRequest(test.config, &p4mocks.DestinationReaderMock{
-				DestinationsFunc: test.destinationsFunc,
-			}, &p4mocks.MerchantReaderMock{
-				OwnerFunc: test.ownerFunc,
+			svc := service.NewPaymentRequest(&p4mocks.PaymentRequestServiceMock{
+				PaymentRequestFunc: test.paymentRequestFunc,
 			})
 
 			resp, err := svc.PaymentRequest(context.TODO(), test.args)


### PR DESCRIPTION
Move away from two http queries for destinations/owners + logic to glue these together, and instead use the payments endpoint available in payd.